### PR TITLE
apostrophe fix

### DIFF
--- a/src/lib/blog/metadata.ts
+++ b/src/lib/blog/metadata.ts
@@ -15,7 +15,7 @@ export const blogPostsMetadata: Record<string, BlogPostMetadata> = {
   'introducing-ignitionai-sparking-intelligent-transformation': {
     id: 'introducing-ignitionai-sparking-intelligent-transformation',
     title: 'Introducing IgnitionAI: Sparking Intelligent Transformation',
-    excerpt: 'We&apos;re bridging the AI gap for small and medium businesses, making intelligent automation accessible, practical, and transformative.',
+    excerpt: 'We\'re bridging the AI gap for small and medium businesses, making intelligent automation accessible, practical, and transformative.',
     publishDate: '2025-08-25',
     author: 'Mario Guerra & Hector Norzagaray',
     category: 'Company Announcement',


### PR DESCRIPTION
This pull request makes a minor update to the `blogPostsMetadata` object in `src/lib/blog/metadata.ts`, fixing the use of an HTML entity in the `excerpt` field for the "Introducing IgnitionAI" blog post.

* Replaced the HTML entity `&apos;` with a plain single quote in the `excerpt` field for the `introducing-ignitionai-sparking-intelligent-transformation` blog post.